### PR TITLE
Add glob matching for scopes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -19,5 +19,7 @@ To do this, please follow this process:
 
 ## Setup
 
-1. install npm, node 12.0.0 and yarn (mac users can use `n`, see https://medium.com/@ExplosionPills/dont-use-sudo-with-npm-still-66e609f5f92)
-2. run tests with `npm run test`
+1. install npm, node 12.0.0 and yarn 
+    1. for Mac: consider using `n`, see https://medium.com/@ExplosionPills/dont-use-sudo-with-npm-still-66e609f5f92)
+2. install dependencies with `yarn install`
+3. run tests with `yarn test`

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,6 +2,8 @@
 
 Thank you very much for contributing to this project!
 
+## Workflow
+
 Due to the way event triggers work with GitHub actions it's a bit harder to test your changes.
 
 Simple changes that can be unit tested can be implemented with the regular workflow where you fork the repo and create a pull request. Note however that the new version of the action won't be executed in the workflows of this repository. We have to rely on the unit tests in this case.
@@ -14,3 +16,8 @@ To do this, please follow this process:
 2. Create a PR in **your own repo**.
 3. The "Lint PR title preview (current branch)" workflow will run the new version and will help you validate the change.
 4. Create a PR to this repo with the changes. In this case the preview workflow will fail, but we'll know that it works since you tested it in the fork. Please include a include a link to a workflow where you tested the current state of this pull request.
+
+## Setup
+
+1. install npm, node 12.0.0 and yarn (mac users can use `n`, see https://medium.com/@ExplosionPills/dont-use-sudo-with-npm-still-66e609f5f92)
+2. run tests with `npm run test`

--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ The action works without configuration, however you can provide options for cust
           types: |
             fix
             feat
-          # Configure which scopes are allowed.
+          # Configure which scopes are allowed, including matching on blobs.
           scopes: |
             core
-            ui
+            ui* 
           # Configure that a scope must always be provided.
           requireScope: true
           # Configure additional validation for the subject based on a regex.

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "@actions/github": "^4.0.0",
     "conventional-changelog-conventionalcommits": "4.5.0",
     "conventional-commit-types": "^3.0.0",
-    "conventional-commits-parser": "^3.2.0"
+    "conventional-commits-parser": "^3.2.0",
+    "minimatch": "^3.0.4"
   },
   "devDependencies": {
     "@semantic-release/changelog": "5.0.1",

--- a/src/validatePrTitle.js
+++ b/src/validatePrTitle.js
@@ -1,6 +1,7 @@
 const conventionalCommitsConfig = require('conventional-changelog-conventionalcommits');
 const conventionalCommitTypes = require('conventional-commit-types');
 const parser = require('conventional-commits-parser').sync;
+const minimatch = require('minimatch');
 const formatMessage = require('./formatMessage');
 
 const defaultTypes = Object.keys(conventionalCommitTypes.types);
@@ -28,8 +29,17 @@ module.exports = async function validatePrTitle(
       .join('\n')}`;
   }
 
-  function isUnknownScope(s) {
-    return scopes && !scopes.includes(s);
+  function isUnknownScope(givenScope) {
+    let unknown = true;
+    if (scopes) {
+      scopes.forEach((scope) => {
+        if (minimatch(givenScope, scope)) {
+          unknown = false;
+        }
+      });
+    }
+
+    return unknown;
   }
 
   if (!result.type) {

--- a/src/validatePrTitle.test.js
+++ b/src/validatePrTitle.test.js
@@ -65,6 +65,18 @@ describe('defined scopes', () => {
     await validatePrTitle('fix(core@TICKET-123): Bar', {scopes: ['core@*']});
   });
 
+  it('allows multiple matching scopes with a non-matching glob', async () => {
+    await validatePrTitle('fix(core,e2e): Bar', {
+      scopes: ['core', 'e2e', 'web', 'pizza*']
+    });
+  });
+
+  it('allows multiple matching scopes with a matching glob', async () => {
+    await validatePrTitle('fix(core,i-like-pizza): Bar', {
+      scopes: ['core', 'e2e', 'web', '*pizza']
+    });
+  });
+
   it('throws when an unknown scope is detected within multiple scopes', async () => {
     await expect(
       validatePrTitle('fix(core,e2e,foo,bar): Bar', {scopes: ['foo', 'core']})

--- a/src/validatePrTitle.test.js
+++ b/src/validatePrTitle.test.js
@@ -61,6 +61,10 @@ describe('defined scopes', () => {
     });
   });
 
+  it('allows a glob match for scopes', async () => {
+    await validatePrTitle('fix(core@TICKET-123): Bar', {scopes: ['core@*']});
+  });
+
   it('throws when an unknown scope is detected within multiple scopes', async () => {
     await expect(
       validatePrTitle('fix(core,e2e,foo,bar): Bar', {scopes: ['foo', 'core']})

--- a/src/validatePrTitle.test.js
+++ b/src/validatePrTitle.test.js
@@ -65,6 +65,14 @@ describe('defined scopes', () => {
     await validatePrTitle('fix(core@TICKET-123): Bar', {scopes: ['core@*']});
   });
 
+  it('throws when an unknown scope is detected when using glob', async () => {
+    await expect(
+      validatePrTitle('fix(core,e2e,foo,bar): Bar', {scopes: ['pizza*']})
+    ).rejects.toThrow(
+      'Unknown scopes "core,e2e,foo,bar" found in pull request title "fix(core,e2e,foo,bar): Bar". Use one of the available scopes: pizza*.'
+    );
+  });
+
   it('allows multiple matching scopes with a non-matching glob', async () => {
     await validatePrTitle('fix(core,e2e): Bar', {
       scopes: ['core', 'e2e', 'web', 'pizza*']


### PR DESCRIPTION
Uses [minimatch](https://github.com/isaacs/minimatch) to allow glob matching of scopes.

Added a new test and all tests pass:
```
➜  action-semantic-pull-request git:(Add-glob-matching-for-scopes) yarn install
yarn install v1.22.10
[1/5] 🔍  Validating package.json...
[2/5] 🔍  Resolving packages...
success Already up-to-date.
✨  Done in 0.51s.
➜  action-semantic-pull-request git:(Add-glob-matching-for-scopes) yarn test
yarn run v1.22.10
$ jest src
 PASS  src/validatePrTitle.test.js
 PASS  src/ConfigParser.test.js
 PASS  src/formatMessage.test.js

Test Suites: 3 passed, 3 total
Tests:       30 passed, 30 total
Snapshots:   0 total
Time:        1.353s
Ran all test suites matching /src/i.
✨  Done in 2.66s.
```